### PR TITLE
IdeaPad 5 15ARE05 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,24 @@
 .PHONY: install uninstall checkroot checkscript checksudo checkacpi
 
-noextname = ideapad5_14are05_energy_mgmt
+# dmidecode produces lots of "Version" lines. `sed -n 'Xp'` (where X is a particular
+# number does not guarantee you will get the machine model. This grep is a hacky-fix to
+# get "IdeaPad" models.
+model_name=$(shell sudo dmidecode | grep "Version: IdeaPad" | sed -n '1p' | cut -d' ' -f2,3,4)
+
+ifeq ("wildcard $(model_name)", "IdeaPad 5 14ARE05")
+	noextname = ideapad5_14are05_energy_mgmt
+endif
+
+ifeq ("$(model_name)", "IdeaPad 5 15ARE05")
+	noextname = ideapad5_15are05_energy_mgmt
+endif
+
+ifeq ("$(noextname)", "")
+	@echo "Model name is invalid."
+	@echo "This machine:$(model_name)"
+	exit 1
+endif
+
 script = $(noextname).sh
 install_path = /usr/local/bin/
 sudorule = $(noextname)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # get "IdeaPad" models.
 model_name=$(shell sudo dmidecode | grep "Version: IdeaPad" | sed -n '1p' | cut -d' ' -f2,3,4)
 
-ifeq ("wildcard $(model_name)", "IdeaPad 5 14ARE05")
+ifeq ("$(model_name)", "IdeaPad 5 14ARE05")
 	noextname = ideapad5_14are05_energy_mgmt
 endif
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Lenovo IdeaPad 5 14ARE05 energy management script
+# Lenovo IdeaPad 5 14ARE05/15ARE05 energy management scripts
 
-This is a bash script that utilizes acpi calls to control certain energy-related aspects of Lenovo Ideapad 5 14ARE05 laptops:
+This is a bash script that utilizes acpi calls to control certain energy-related aspects of Lenovo Ideapad 5 14ARE05/15ARE05 laptops:
 
   * rapid charge
   * battery conservation (limits the maximum charge of the battery at the level of 55-60% to prolong the life of the battery)
@@ -32,10 +32,15 @@ In order to uninstall the following command must be executed:
 
 	sudo make uninstall
 
-### Usage
+### Usage (14ARE05)
 
 
-	sudo /usr/local/bin/ideapad5_14are05_energy_mgmt.sh perf_mode [..params..]|rapid_charge [on|off]|batt_conserv [on|off]
+	sudo /usr/local/bin/ideapad5_14are05_energy_mgmt.sh status|perf_mode [..params..]|rapid_charge [on|off]|batt_conserv [on|off]
+
+### Usage (15ARE05)
+
+
+	sudo /usr/local/bin/ideapad5_15are05_energy_mgmt.sh status|perf_mode [..params..]|rapid_charge [on|off]|batt_conserv [on|off]
 
 parameters for 'perf\_mode':
 


### PR DESCRIPTION
* New script added for 15ARE05 support.
* Makefile will install correct script, depending on laptop model.
* `status` option added, to get the status of all options.

I won't be offended if you have no interest in merging this, just giving the option. I know this repo is really for the Ideapad 5 14 only.

Also any improvement suggestions are very welcome. I don't really know bash and make.

Also also, I have made changes to the 14are05 script too. But I can't really test the script since I don't own a 14are05. So that script may be broken.